### PR TITLE
Add new dependencies to fix downstream convergence errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,8 @@
         <dropwizard.version>2.0.29</dropwizard.version>
         <dropwizard.metrics.version>4.1.31</dropwizard.metrics.version>
         <embed.mongo.version>3.4.5</embed.mongo.version>
+        <embed.mongo.os.version>1.1.8</embed.mongo.os.version>
+        <embed.mongo.process.version>3.1.10</embed.mongo.process.version>
         <embedded-consul.version>2.2.1</embedded-consul.version>
         <embedded-postgres.version>1.3.1</embedded-postgres.version>
         <error-prone-annotations.version>2.12.1</error-prone-annotations.version>
@@ -214,6 +216,18 @@
                 <groupId>de.flapdoodle.embed</groupId>
                 <artifactId>de.flapdoodle.embed.mongo</artifactId>
                 <version>${embed.mongo.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>de.flapdoodle</groupId>
+                <artifactId>de.flapdoodle.os</artifactId>
+                <version>${embed.mongo.os.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>de.flapdoodle.embed</groupId>
+                <artifactId>de.flapdoodle.embed.process</artifactId>
+                <version>${embed.mongo.process.version}</version>
             </dependency>
 
             <dependency>
@@ -522,6 +536,18 @@
 
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-http</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-io</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-server</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
@@ -529,6 +555,12 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-servlet</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-util</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
 


### PR DESCRIPTION
This adds several new dependencies to the dependency management section
to fix convergence errors that occur downstream without them. They
occur because of internal inconsistencies within other libraries, e.g.
the embedded mongo library (groupId de.flapdoodle) specifies different
versions for de.flapdoodle.os and de.flapdoodle.embed.process in its
own POMS.

The following dependencies are added:

* de.flapdoodle:de.flapdoodle.os:1.1.8
* de.flapdoodle:de.flapdoodle.embed.process:3.1.10
* org.eclipse.jetty:jetty-http:9.4.46.v20220331
* org.eclipse.jetty:jetty-io:9.4.46.v20220331
* org.eclipse.jetty:jetty-util:9.4.46.v20220331