### PR TITLE
"Deprecate" the mongo-java-driver dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -684,6 +684,11 @@
                 <version>${mockito.version}</version>
             </dependency>
 
+            <!-- DEPRECATED: This dependency will be removed in a future release. -->
+            <!--
+                It is being deprecated and remains in this BOM in order to make
+                migration to the new Mongo drivers easier.
+            -->
             <dependency>
                 <groupId>org.mongodb</groupId>
                 <artifactId>mongo-java-driver</artifactId>


### PR DESCRIPTION
While there is no official way to deprecate a dependency in Maven,
we are unofficially deprecating it bu leaving it in the POM to make
transitioning from the legacy (3.x) Mongo driver to the new 4.x
driver easier.

Closes #163