### PR TITLE
Add version property for logback-classic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,8 @@
         <junit.platform.commons.version>1.8.2</junit.platform.commons.version>
         <kotlin.version>1.6.20</kotlin.version>
         <liquibase.version>3.10.3</liquibase.version>
+        <logback-classic.version>1.2.11</logback-classic.version>
+        <logback-core.version>1.2.11</logback-core.version>
         <logstash.version>6.6</logstash.version>
         <mongodb-driver-core.version>4.5.1</mongodb-driver-core.version>
         <mongodb-driver-reactivestreams.version>4.5.1</mongodb-driver-reactivestreams.version>
@@ -654,13 +656,13 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>${logback.version}</version>
+                <version>${logback-classic.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
-                <version>${logback.version}</version>
+                <version>${logback-core.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
We have been inheriting the logback.version property from the
kiwi-parent POM, but this has been removed from kiwi-parent.
The logback-classic and logback-core dependencies are already
defined in this BOM, but this commit introduces separate version
properties so that, if one ever has a patch version while other
does not, we can accomodate by changing one or the other of
logback-classic.verion or logback.core.version. Of course, this does
mean if they both change, we have to change both of them, but this
doesn't happen too often and they are right next to each other.

Closes #167