### PR TITLE
Revert latest spring-data-mongodb and mongo-driver-xxx versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,9 +85,9 @@
         <logback-classic.version>1.2.11</logback-classic.version>
         <logback-core.version>1.2.11</logback-core.version>
         <logstash.version>6.6</logstash.version>
-        <mongodb-driver-core.version>4.6.0</mongodb-driver-core.version>
-        <mongodb-driver-reactivestreams.version>4.6.0</mongodb-driver-reactivestreams.version>
-        <mongodb-driver-sync.version>4.6.0</mongodb-driver-sync.version>
+        <mongodb-driver-core.version>4.5.1</mongodb-driver-core.version>
+        <mongodb-driver-reactivestreams.version>4.5.1</mongodb-driver-reactivestreams.version>
+        <mongodb-driver-sync.version>4.5.1</mongodb-driver-sync.version>
         <mongo-java-driver.version>3.12.10</mongo-java-driver.version>
         <mongo-java-server.version>1.39.0</mongo-java-server.version>
         <netty.version>4.1.76.Final</netty.version>
@@ -96,7 +96,7 @@
         <servo-core.version>0.13.2</servo-core.version>
         <slf4j-api.version>1.7.36</slf4j-api.version>
         <spring.version>5.3.19</spring.version>
-        <spring-data-mongodb.version>3.3.4</spring-data-mongodb.version>
+        <spring-data-mongodb.version>3.3.3</spring-data-mongodb.version>
         <stax-ex.version>1.8.3</stax-ex.version>
         <stax2-api.version>4.2.1</stax2-api.version>
         <woodstox-core.version>6.2.8</woodstox-core.version>


### PR DESCRIPTION
* Revert spring-data-mongodb from 3.3.4 to 3.3.3
* Revert mongo-driver-xxx from 4.6.0 to 4.5.1

I should not have accepted these updates without fully testing them
against kiwi and kiwi-test. There is some issue with the JDK 16 build
where we get the following error:

 UnsupportedClassVersion org/bson/codecs/record/RecordCodecProvider
 has been compiled by a more recent version of the Java Runtime (class
 file version 61.0), this version of the Java Runtime only recognizes
 class file versions up to 60.0

Class file version 61.0 is JDK 17, while 60.0 is JDK 16. For now, I
am reverting to the earlier versions which compiled and all tests
passed in kiwi and kiwi-test under both JDK 11 and 16.