### PR TITLE
Add spring-data-commons dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
         <servo-core.version>0.13.2</servo-core.version>
         <slf4j-api.version>1.7.36</slf4j-api.version>
         <spring.version>5.3.19</spring.version>
+        <spring-data-commons.version>2.6.4</spring-data-commons.version>
         <spring-data-mongodb.version>3.3.4</spring-data-mongodb.version>
         <stax-ex.version>1.8.3</stax-ex.version>
         <stax2-api.version>4.2.1</stax2-api.version>
@@ -793,6 +794,12 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-core</artifactId>
                 <version>${spring.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.data</groupId>
+                <artifactId>spring-data-commons</artifactId>
+                <version>${spring-data-commons.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Add spring-data-commons dependency as an explicit dependency. This will
allow us to control its version independently if necessary.

Closes #181