### PR TITLE
Import the Dropwizard BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,62 +239,10 @@
 
             <dependency>
                 <groupId>io.dropwizard</groupId>
-                <artifactId>dropwizard-client</artifactId>
+                <artifactId>dropwizard-bom</artifactId>
                 <version>${dropwizard.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.dropwizard</groupId>
-                <artifactId>dropwizard-core</artifactId>
-                <version>${dropwizard.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.dropwizard</groupId>
-                <artifactId>dropwizard-db</artifactId>
-                <version>${dropwizard.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.dropwizard</groupId>
-                <artifactId>dropwizard-jackson</artifactId>
-                <version>${dropwizard.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.dropwizard</groupId>
-                <artifactId>dropwizard-jersey</artifactId>
-                <version>${dropwizard.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.dropwizard</groupId>
-                <artifactId>dropwizard-jdbi3</artifactId>
-                <version>${dropwizard.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.dropwizard</groupId>
-                <artifactId>dropwizard-lifecycle</artifactId>
-                <version>${dropwizard.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.dropwizard</groupId>
-                <artifactId>dropwizard-logging</artifactId>
-                <version>${dropwizard.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.dropwizard</groupId>
-                <artifactId>dropwizard-testing</artifactId>
-                <version>${dropwizard.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.dropwizard</groupId>
-                <artifactId>dropwizard-util</artifactId>
-                <version>${dropwizard.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Rather than explicitly listing all the various dropwizard-xxx
dependencies, just import the dropwizard-bom dependency which
provides all the dropwizard-xxx dependencies locked to the specific
version.

Closes #210
Closes #203