### PR TITLE
Match Dropwizard 2.1.0 dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <consul-client.version>1.5.3</consul-client.version>
         <curator.version>5.2.1</curator.version>
         <dropwizard.version>2.1.0</dropwizard.version>
-        <dropwizard.metrics.version>4.1.31</dropwizard.metrics.version>
+        <dropwizard.metrics.version>4.2.9</dropwizard.metrics.version>
         <embed.mongo.version>3.4.5</embed.mongo.version>
         <embed.mongo.os.version>1.1.8</embed.mongo.os.version>
         <embed.mongo.process.version>3.1.10</embed.mongo.process.version>


### PR DESCRIPTION
* Bump dropwizard-metrics version from 4.1.31 to 4.2.9

For every other dependency that we have in common with Dropwizard,
we are already at their version, or we're slightly higher version, e.g.
we're on Hibernate 5.6.9 while Dropwizard 2.1.0 is on 5.6.8.

Closes #206