### PR TITLE
Match Dropwizard 2.1.0 dependency versions (missed Hibernate Validator)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <guava.version>31.1-jre</guava.version>
         <h2.version>2.1.212</h2.version>
         <hibernate.version>5.6.9.Final</hibernate.version>
-        <hibernate-validator.version>6.1.7.Final</hibernate-validator.version>
+        <hibernate-validator.version>6.2.3.Final</hibernate-validator.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.15</httpcore.version>
         <jackson.version>2.13.3</jackson.version>


### PR DESCRIPTION
* Bump hibernate-validator version from 6.1.7.Final to 6.2.3.Final

Closes #206