### PR TITLE
Import Netty BOM instead of individual Netty components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -618,35 +618,7 @@
 
             <dependency>
                 <groupId>io.netty</groupId>
-                <artifactId>netty-buffer</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
-
-            <!--
-                This was added to resolve conflicts with mongo-java-server.
-                It should be re-evaluated from time-to-time.
-            -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-common</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-handler</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport</artifactId>
+                <artifactId>netty-bom</artifactId>
                 <version>${netty.version}</version>
             </dependency>
 


### PR DESCRIPTION
Rather than explicitly listing all the various netty-xxx
dependencies, import the netty-bom dependency which provides
all the netty-xxx dependencies locked to the specific version.

References #60