### PR TITLE
Clean up JUnit dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,6 @@
         <jsonassert.version>1.5.1</jsonassert.version>
         <jsch.version>0.1.55</jsch.version>
         <jsr305.version>3.0.2</jsr305.version>
-        <junit.platform.commons.version>1.9.0</junit.platform.commons.version>
         <kotlin.version>1.7.10</kotlin.version>
         <liquibase.version>4.14.0</liquibase.version>
         <logback-classic.version>1.2.11</logback-classic.version>
@@ -496,30 +495,6 @@
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>jsr305</artifactId>
                 <version>${jsr305.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-api</artifactId>
-                <version>${junit.jupiter.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-engine</artifactId>
-                <version>${junit.jupiter.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-params</artifactId>
-                <version>${junit.jupiter.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.junit.platform</groupId>
-                <artifactId>junit-platform-commons</artifactId>
-                <version>${junit.platform.commons.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
* Remove all JUnit dependencies from this BOM; kiwi-parent now includes
  junit-bom in its own dependency management and declares several JUnit
  dependencies directly.

Closes #305