### PR TITLE
Revert logback-xyz dependencies to 1.3.1 to use javax namespace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,9 +77,9 @@
         <jsr305.version>3.0.2</jsr305.version>
         <kotlin.version>1.7.10</kotlin.version>
         <liquibase.version>4.16.1</liquibase.version>
-        <logback-access.version>1.4.1</logback-access.version>
-        <logback-classic.version>1.4.1</logback-classic.version>
-        <logback-core.version>1.4.1</logback-core.version>
+        <logback-access.version>1.3.1</logback-access.version>
+        <logback-classic.version>1.3.1</logback-classic.version>
+        <logback-core.version>1.3.1</logback-core.version>
         <logstash.version>7.2</logstash.version>
         <mongodb-driver-core.version>4.7.1</mongodb-driver-core.version>
         <mongodb-driver-reactivestreams.version>4.7.1</mongodb-driver-reactivestreams.version>


### PR DESCRIPTION
Fixes #364