### PR TITLE
Bump jetty to 9.4.49.v20220914

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <jboss-logging.version>3.5.0.Final</jboss-logging.version>
         <jdbi3.version>3.33.0</jdbi3.version>
         <jersey.version>2.37</jersey.version>
-        <jetty.version>9.4.48.v20220622</jetty.version>
+        <jetty.version>9.4.49.v20220914</jetty.version>
         <joda-time.version>2.11.2</joda-time.version>
         <jsonassert.version>1.5.1</jsonassert.version>
         <jsch.version>0.1.55</jsch.version>


### PR DESCRIPTION
* Bump jetty from 9.4.48.v20220622 to 9.4.49.v20220914

NOTE: At release 9.4.49.v20220914, the End of Life for Jetty 9.4.x was announced. For more details see:
https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.49.v20220914