### PR TITLE
Add additional org.slf4j dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,9 @@
         <servo-core.version>0.13.2</servo-core.version>
         <snakeyaml.version>1.33</snakeyaml.version>
         <slf4j-api.version>2.0.3</slf4j-api.version>
+        <slf4j.jul-to-slf4j.version>2.0.3</slf4j.jul-to-slf4j.version>
+        <slf4j.log4j-over-slf4j.version>2.0.3</slf4j.log4j-over-slf4j.version>
+        <slf4j.jcl-over-slf4j.version>2.0.3</slf4j.jcl-over-slf4j.version>
         <spring.version>5.3.23</spring.version>
         <spring-data-commons.version>2.7.3</spring-data-commons.version>
         <spring-data-mongodb.version>3.4.3</spring-data-mongodb.version>
@@ -557,6 +560,24 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>${slf4j.jcl-over-slf4j.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jul-to-slf4j</artifactId>
+                <version>${slf4j.jul-to-slf4j.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>log4j-over-slf4j</artifactId>
+                <version>${slf4j.log4j-over-slf4j.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
* Add jcl-over-slf4j
* Add jul-over-slf4j
* Add log4j-over-slf4j
* Defined separate versions for each of the above, just in case they are not released in lock-step. Since SLF4J does not have an overarching BOM, this is possible even if unlikely, e.g. for a bug fix.

Closes #390