### PR TITLE
Revert logback to 1.3.x which supports JavaEE and the javax namespace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,9 +77,9 @@
         <jsr305.version>3.0.2</jsr305.version>
         <kotlin.version>1.7.20</kotlin.version>
         <liquibase.version>4.16.1</liquibase.version>
-        <logback-access.version>1.4.3</logback-access.version>
-        <logback-classic.version>1.4.3</logback-classic.version>
-        <logback-core.version>1.4.3</logback-core.version>
+        <logback-access.version>1.3.4</logback-access.version>
+        <logback-classic.version>1.3.4</logback-classic.version>
+        <logback-core.version>1.3.4</logback-core.version>
         <logstash.version>7.2</logstash.version>
         <mongodb-driver-core.version>4.7.2</mongodb-driver-core.version>
         <mongodb-driver-reactivestreams.version>4.7.2</mongodb-driver-reactivestreams.version>


### PR DESCRIPTION
At present, we must use the 1.3.x series because Dropwizard 2.1.x is still using JavaEE and the javax namespace (Jetty 9.x).

For details, see https://logback.qos.ch/dependencies.html

Fixes #394