### PR TITLE
Bump logback dependencies to 1.3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,9 +77,9 @@
         <jsr305.version>3.0.2</jsr305.version>
         <kotlin.version>1.7.21</kotlin.version>
         <liquibase.version>4.17.2</liquibase.version>
-        <logback-access.version>1.3.4</logback-access.version>
-        <logback-classic.version>1.3.4</logback-classic.version>
-        <logback-core.version>1.3.4</logback-core.version>
+        <logback-access.version>1.3.5</logback-access.version>
+        <logback-classic.version>1.3.5</logback-classic.version>
+        <logback-core.version>1.3.5</logback-core.version>
         <logstash.version>7.2</logstash.version>
         <mongodb-driver-core.version>4.8.0</mongodb-driver-core.version>
         <mongodb-driver-reactivestreams.version>4.8.0</mongodb-driver-reactivestreams.version>


### PR DESCRIPTION
* Bump logback-access from 1.3.4 to 1.3.5
* Bump logback-classic from 1.3.4 to 1.3.5
* Bump logback-core from 1.3.4 to 1.3.5