### PR TITLE
Remove embedded-consul from BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,6 @@
         <curator.version>5.4.0</curator.version>
         <dropwizard.version>2.1.5</dropwizard.version>
         <dropwizard.metrics.version>4.2.17</dropwizard.metrics.version>
-        <embedded-consul.version>2.2.1</embedded-consul.version>
         <embedded-postgres.version>2.0.3</embedded-postgres.version>
         <error-prone-annotations.version>2.18.0</error-prone-annotations.version>
         <eureka.version>1.10.18</eureka.version>
@@ -215,12 +214,6 @@
                 <version>${dropwizard.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>com.pszymczyk.consul</groupId>
-                <artifactId>embedded-consul</artifactId>
-                <version>${embedded-consul.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
The embedded-consul library was retired, saying that Testcontainers are preferred.

We updated our only library which was using embedded-consul (service-discovery-client) to use Testcontainers, so we can remove this dependency now.

Closes #596