### PR TITLE
Bump jetty from 9.4.49.v20220914 to 9.4.51.v20230217

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <jboss-logging.version>3.5.0.Final</jboss-logging.version>
         <jdbi3.version>3.37.1</jdbi3.version>
         <jersey.version>2.37</jersey.version>
-        <jetty.version>9.4.49.v20220914</jetty.version>
+        <jetty.version>9.4.51.v20230217</jetty.version>
         <joda-time.version>2.12.2</joda-time.version>
         <jsonassert.version>1.5.1</jsonassert.version>
         <jsch.version>0.1.55</jsch.version>


### PR DESCRIPTION
Closes #600 