### PR TITLE
Bump logback-xxx from 1.3.6 to 1.3.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,9 @@
         <jsr305.version>3.0.2</jsr305.version>
         <kotlin.version>1.8.20</kotlin.version>
         <liquibase.version>4.21.1</liquibase.version>
-        <logback-access.version>1.3.6</logback-access.version>
-        <logback-classic.version>1.3.6</logback-classic.version>
-        <logback-core.version>1.3.6</logback-core.version>
+        <logback-access.version>1.3.7</logback-access.version>
+        <logback-classic.version>1.3.7</logback-classic.version>
+        <logback-core.version>1.3.7</logback-core.version>
         <logstash.version>7.3</logstash.version>
         <mongodb-driver-core.version>4.9.1</mongodb-driver-core.version>
         <mongodb-driver-reactivestreams.version>4.9.1</mongodb-driver-reactivestreams.version>


### PR DESCRIPTION
* Bumps the version of logback-access, logback-classic, and logback-core