### PR TITLE
Bump spring and spring-data versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,9 +90,9 @@
         <slf4j.jul-to-slf4j.version>2.0.7</slf4j.jul-to-slf4j.version>
         <slf4j.log4j-over-slf4j.version>2.0.7</slf4j.log4j-over-slf4j.version>
         <slf4j.jcl-over-slf4j.version>2.0.7</slf4j.jcl-over-slf4j.version>
-        <spring.version>5.3.28</spring.version>
-        <spring-data-commons.version>2.7.13</spring-data-commons.version>
-        <spring-data-mongodb.version>3.4.13</spring-data-mongodb.version>
+        <spring.version>5.3.29</spring.version>
+        <spring-data-commons.version>2.7.14</spring-data-commons.version>
+        <spring-data-mongodb.version>3.4.14</spring-data-mongodb.version>
         <stax-ex.version>1.8.3</stax-ex.version>
         <stax2-api.version>4.2.1</stax2-api.version>
         <woodstox-core.version>6.5.1</woodstox-core.version>


### PR DESCRIPTION
* Bump spring from 5.3.28 to 5.3.29
* Bump spring-data-commons from 2.7.13 to 2.7.14
* Bump spring-data-mongodb from 3.4.13 to 3.4.14