### PR TITLE
Update to Dropwizard 4.x and other new major versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>org.kiwiproject</groupId>
         <artifactId>kiwi-parent</artifactId>
-        <version>2.0.20</version>
+        <version>3.0.0</version>
     </parent>
 
     <artifactId>kiwi-bom</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -27,6 +27,7 @@
     </scm>
 
     <properties>
+        <angus-activation.version>2.0.1</angus-activation.version>
         <ant.version>1.10.13</ant.version>
         <archaius-core.version>0.7.7</archaius-core.version>
         <assertj-guava.version>3.24.2</assertj-guava.version>
@@ -35,46 +36,55 @@
         <checker-qual.version>3.37.0</checker-qual.version>
         <classmate.version>1.5.1</classmate.version>
         <commons-codec.version>1.16.0</commons-codec.version>
+        <commons-compress.version>1.23.0</commons-compress.version>
         <commons-io.version>2.13.0</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
         <commons-lang3.version>3.13.0</commons-lang3.version>
         <commons-logging.version>1.2</commons-logging.version>
-        <consul-client.version>1.5.3</consul-client.version>
         <curator.version>5.5.0</curator.version>
-        <dropwizard.version>2.1.7</dropwizard.version>
+        <dropwizard.version>4.0.1</dropwizard.version>
         <dropwizard.metrics.version>4.2.19</dropwizard.metrics.version>
         <embedded-postgres.version>2.0.4</embedded-postgres.version>
         <error-prone-annotations.version>2.21.1</error-prone-annotations.version>
         <eureka.version>1.10.18</eureka.version>
-        <fastinfoset.version>1.2.18</fastinfoset.version>
+        <fastinfoset.version>2.1.0</fastinfoset.version>
         <guava.version>32.1.2-jre</guava.version>
         <h2.version>2.2.220</h2.version>
-        <hibernate.version>5.6.15.Final</hibernate.version>
-        <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>
+        <hamcrest.version>2.2</hamcrest.version>
+        <hibernate.version>6.2.7.Final</hibernate.version>
+        <hibernate-validator.version>7.0.5.Final</hibernate-validator.version>
+        <hk2.version>3.0.4</hk2.version>
         <httpclient.version>4.5.14</httpclient.version>
+        <httpclient5.version>5.2.1</httpclient5.version>
         <httpcore.version>4.4.16</httpcore.version>
+        <httpcore5.version>5.2.2</httpcore5.version>
         <jackson.version>2.15.2</jackson.version>
-        <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
-        <jakarta.activation-api.version>1.2.2</jakarta.activation-api.version>
-        <jakarta.el.version>3.0.4</jakarta.el.version>
-        <jakarta.servlet-api.version>4.0.4</jakarta.servlet-api.version>
-        <jakarta.xml.bind-api.version>2.3.3</jakarta.xml.bind-api.version>
+        <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
+        <jakarta.activation-api.version>2.1.2</jakarta.activation-api.version>
+        <jakarta.activation-api.sun.version>2.0.1</jakarta.activation-api.sun.version>
+        <jakarta.el.version>4.0.2</jakarta.el.version>
+        <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
+        <jakarta.ws.rs-api.version>3.0.0</jakarta.ws.rs-api.version>
+        <jakarta.servlet-api.version>5.0.0</jakarta.servlet-api.version>
+        <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
+        <jakarta.xml.bind-api.version>3.0.1</jakarta.xml.bind-api.version>
         <javassist.version>3.29.2-GA</javassist.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
-        <jaxws-rt.version>2.3.6</jaxws-rt.version>
+        <jaxws-rt.version>4.0.1</jaxws-rt.version>
         <jboss-logging.version>3.5.3.Final</jboss-logging.version>
-        <jdbi3.version>3.37.1</jdbi3.version>
-        <jersey.version>2.40</jersey.version>
-        <jetty.version>9.4.51.v20230217</jetty.version>
+        <jdbi3.version>3.40.0</jdbi3.version>
+        <jersey.version>3.0.11</jersey.version>
+        <jetbrains-annotations.version>24.0.1</jetbrains-annotations.version>
+        <jetty.version>11.0.15</jetty.version>
         <joda-time.version>2.12.5</joda-time.version>
         <jsonassert.version>1.5.1</jsonassert.version>
         <jsch.version>0.1.55</jsch.version>
         <jsr305.version>3.0.2</jsr305.version>
         <kotlin.version>1.9.0</kotlin.version>
         <liquibase.version>4.23.0</liquibase.version>
-        <logback-access.version>1.3.8</logback-access.version>
-        <logback-classic.version>1.3.8</logback-classic.version>
-        <logback-core.version>1.3.8</logback-core.version>
+        <logback-access.version>1.4.9</logback-access.version>
+        <logback-classic.version>1.4.9</logback-classic.version>
+        <logback-core.version>1.4.9</logback-core.version>
         <logstash.version>7.4</logstash.version>
         <mongodb-driver-core.version>4.10.2</mongodb-driver-core.version>
         <mongodb-driver-reactivestreams.version>4.10.2</mongodb-driver-reactivestreams.version>
@@ -90,13 +100,13 @@
         <slf4j.jul-to-slf4j.version>2.0.7</slf4j.jul-to-slf4j.version>
         <slf4j.log4j-over-slf4j.version>2.0.7</slf4j.log4j-over-slf4j.version>
         <slf4j.jcl-over-slf4j.version>2.0.7</slf4j.jcl-over-slf4j.version>
-        <spring.version>5.3.29</spring.version>
-        <spring-data-commons.version>2.7.14</spring-data-commons.version>
-        <spring-data-mongodb.version>3.4.14</spring-data-mongodb.version>
-        <stax-ex.version>1.8.3</stax-ex.version>
+        <spring.version>6.0.11</spring.version>
+        <spring-data-commons.version>3.1.2</spring-data-commons.version>
+        <spring-data-mongodb.version>4.1.2</spring-data-mongodb.version>
+        <stax-ex.version>2.1.0</stax-ex.version>
         <stax2-api.version>4.2.1</stax2-api.version>
         <woodstox-core.version>6.5.1</woodstox-core.version>
-        <zookeeper.version>3.8.2</zookeeper.version>
+        <zookeeper.version>3.9.0</zookeeper.version>
 
         <!-- Sonar properties -->
         <sonar.projectKey>kiwiproject_kiwi-bom</sonar.projectKey>
@@ -106,6 +116,18 @@
 
     <dependencyManagement>
         <dependencies>
+            <!--
+                This is a runtime dependency of jax-ws as well as saaj-impl (Jakarta SOAP with Attachments).
+                And, jaxws-rt has a runtime dependency on saaj-impl. As of jax-ws 4.0.1 there is a version conflict
+                between these two: jax-ws depends on version 2.0.0 but saaj-impl depends on 1.0.0, so we are
+                choosing to bind to 2.0.0 here, since jaxws-rt depends on the 2.0.0 version.
+            -->
+            <dependency>
+                <groupId>org.eclipse.angus</groupId>
+                <artifactId>angus-activation</artifactId>
+                <version>${angus-activation.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
@@ -167,6 +189,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>${commons-compress.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons-io.version}</version>
@@ -188,12 +216,6 @@
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
                 <version>${commons-logging.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.orbitz.consul</groupId>
-                <artifactId>consul-client</artifactId>
-                <version>${consul-client.version}</version>
             </dependency>
 
             <dependency>
@@ -260,7 +282,13 @@
             </dependency>
 
             <dependency>
-                <groupId>org.hibernate</groupId>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest</artifactId>
+                <version>${hamcrest.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hibernate.orm</groupId>
                 <artifactId>hibernate-core</artifactId>
                 <version>${hibernate.version}</version>
             </dependency>
@@ -272,15 +300,35 @@
             </dependency>
 
             <dependency>
+                <groupId>org.glassfish.hk2</groupId>
+                <artifactId>hk2-bom</artifactId>
+                <version>${hk2.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
                 <version>${httpclient.version}</version>
             </dependency>
 
             <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5</artifactId>
+                <version>${httpclient5.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
                 <version>${httpcore.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5</artifactId>
+                <version>${httpcore5.version}</version>
             </dependency>
 
             <dependency>
@@ -299,7 +347,7 @@
             <dependency>
                 <groupId>com.sun.activation</groupId>
                 <artifactId>jakarta.activation</artifactId>
-                <version>${jakarta.activation-api.version}</version>
+                <version>${jakarta.activation-api.sun.version}</version>
             </dependency>
 
             <dependency>
@@ -321,9 +369,27 @@
             </dependency>
 
             <dependency>
+                <groupId>jakarta.inject</groupId>
+                <artifactId>jakarta.inject-api</artifactId>
+                <version>${jakarta.inject-api.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>jakarta.servlet</groupId>
                 <artifactId>jakarta.servlet-api</artifactId>
                 <version>${jakarta.servlet-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>${jakarta.ws.rs-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
+                <version>${jakarta.validation-api.version}</version>
             </dependency>
 
             <dependency>
@@ -370,6 +436,12 @@
                 <version>${jersey.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jetbrains</groupId>
+                <artifactId>annotations</artifactId>
+                <version>${jetbrains-annotations.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
The following are the new major versions:

* Dropwizard 4.x (uses Jakarta EE 9 and the Jakarta namespace)
* Dropwizard Metrics 4.x (this has not changed)
* Hibernate 6.x
* Hibernate Validator 7.x (Jakarta EE 9)
* Jersey 3.0.x (Jakarta EE 9)
* Jetty 11.x (Jakarta EE 9)
* Logback 1.4.x (Jakarta namespace)
* Spring 6.x (requires JDK 17)
* Spring Data Commons 3.x
* Spring Data MongoDB 4.x

The following dependencies were also updated to new major versions (other than the above major versions):

* FastInfoset (com.sun.xml.fastinfoset » FastInfoset)
* Various Jakarta dependencies (related to Jakarta EE 9)

The following are added to the BOM:

* Apache Commons Compress (org.apache.commons » commons-compress)
* Angus Activation Registries Implementation (org.eclipse.angus » angus-activation - resolves version conflict between jaws-rt and saaj-impl)
* Hamcrest (org.hamcrest » hamcrest)
* HK2 BOM (org.glassfish.hk2 » hk2-bom)
* Apache HttpClient 5 (org.apache.httpcomponents.client5 » httpclient5)
* Apache HttpComponents Core 5 (org.apache.httpcomponents.core5 » httpcore5)
* JetBrains Java Annotations (org.jetbrains » annotations)
* ZooKeeper (org.apache.zookeeper » zookeeper - the 3.9.0 client is compatible with older servers as long as new APIs are not used)

The following are dropped from the BOM:

* Orbitz Consul Client (com.orbitz.consul »consul-client - use org.kiwiproject » consul-client instead)

Closes #747