### PR TITLE
Remove obsolete exclusion from zookeeper dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -665,13 +665,6 @@
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
                 <version>${zookeeper.version}</version>
-                <exclusions>
-                    <!-- This conflicts with log4j-over-slf4j which dropwizard brings in -->
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-log4j12</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
* Remove slf4j-log4j12 exclusion from zookeeper; this is obsolete. Zookeeper hasn't used this dependency since version 3.7.0. See https://mvnrepository.com/artifact/org.apache.zookeeper/zookeeper/3.7.0