### PR TITLE
Revert jetty-bom from 12.0.6 to 11.0.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <jdbi3.version>3.44.0</jdbi3.version>
         <jersey.version>3.0.12</jersey.version>
         <jetbrains-annotations.version>24.1.0</jetbrains-annotations.version>
-        <jetty.version>12.0.6</jetty.version>
+        <jetty.version>11.0.20</jetty.version>
         <joda-time.version>2.12.7</joda-time.version>
         <jsonassert.version>1.5.1</jsonassert.version>
         <jsch.version>0.1.55</jsch.version>


### PR DESCRIPTION
I missed this one while merging PRs. We can't update to Jetty 12.x until Dropwizard 5.x, which is still in alpha releases. So, revert the jetty-bom version to the most recent 11.x version.