### PR TITLE
Exclude Jersey and Jakarta Validation API from group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
+        exclude-patterns:
+          - "jersey-bom"
+          - "jakarta.validation-api"
     assignees:
       - "sleberknight"
       - "chrisrohr"


### PR DESCRIPTION
These dependencies have minor versions which correspond to MAJOR versions of Jakarta EE, so we can't include these.