### PR TITLE
Revert logback-classic and logback-core to 1.5.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,8 @@
         <liquibase.version>4.30.0</liquibase.version>
         <logback-access-1_x.version>1.4.14</logback-access-1_x.version>
         <logback-access-2_x.version>2.0.3</logback-access-2_x.version>
-        <logback-classic.version>1.5.15</logback-classic.version>
-        <logback-core.version>1.5.15</logback-core.version>
+        <logback-classic.version>1.5.12</logback-classic.version>
+        <logback-core.version>1.5.12</logback-core.version>
         <logstash.version>8.0</logstash.version>
         <mongodb-driver-core.version>5.2.1</mongodb-driver-core.version>
         <mongodb-driver-reactivestreams.version>5.2.1</mongodb-driver-reactivestreams.version>


### PR DESCRIPTION
This is the highest version of these libraries that we can use with Dropwizard 4.x (and even the alpha versions of 5.x). We also must remain on logback-access 1.4.14 or else Dropwizard code can't work because it depends on the 1.4.x logback-access, which has a different package than the newer logback-access 2.0.x versions.

Dropwizard needs to update their usage of Logback classic, core, and access for us to move beyond these versions. :-(

Fixes #1239