### PR TITLE
Exclude logback dependencies from grouped dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
         exclude-patterns:
           - "org.glassfish.jersey:*"
           - "jakarta.validation:jakarta.validation-api"
+          - "ch.qos.logback:*"
     assignees:
       - "sleberknight"
       - "chrisrohr"


### PR DESCRIPTION
Currently, we cannot go beyond logback-core/classic 1.5.12 for the reasons described in #1239 so exclude logback from the dependabot grouped updates.