### PR TITLE
Bump org.eclipse.jetty:jetty-bom from 11.0.24 to 11.0.25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <jdbi3.version>3.48.0</jdbi3.version>
         <jersey.version>3.0.17</jersey.version>
         <jetbrains-annotations.version>26.0.2</jetbrains-annotations.version>
-        <jetty.version>11.0.24</jetty.version>
+        <jetty.version>11.0.25</jetty.version>
         <joda-time.version>2.13.1</joda-time.version>
         <jsonassert.version>1.5.3</jsonassert.version>
         <jsch.version>0.1.55</jsch.version>


### PR DESCRIPTION
see https://github.com/jetty/jetty.project/releases/tag/jetty-11.0.25