### PR TITLE
Remove legacy 1.x logback access

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,7 @@
         <jsr305.version>3.0.2</jsr305.version>
         <kotlin.version>2.1.20</kotlin.version>
         <liquibase.version>4.31.1</liquibase.version>
-        <logback-access-1_x.version>1.4.14</logback-access-1_x.version>
-        <logback-access-2_x.version>2.0.6</logback-access-2_x.version>
+        <logback-access.version>2.0.6</logback-access.version>
         <logback-classic.version>1.5.18</logback-classic.version>
         <logback-core.version>1.5.18</logback-core.version>
         <logstash.version>8.0</logstash.version>
@@ -528,30 +527,22 @@
                 <version>${liquibase.version}</version>
             </dependency>
 
-            <!-- 1.x version of logback-access (legacy version) -->
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-access</artifactId>
-                <version>${logback-access-1_x.version}</version>
-            </dependency>
-
-            <!-- 2.x version of logback-access (new version, supports jetty 11 and higher -->
             <dependency>
                 <groupId>ch.qos.logback.access</groupId>
                 <artifactId>logback-access-common</artifactId>
-                <version>${logback-access-2_x.version}</version>
+                <version>${logback-access.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>ch.qos.logback.access</groupId>
                 <artifactId>logback-access-jetty11</artifactId>
-                <version>${logback-access-2_x.version}</version>
+                <version>${logback-access.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>ch.qos.logback.access</groupId>
                 <artifactId>logback-access-jetty12</artifactId>
-                <version>${logback-access-2_x.version}</version>
+                <version>${logback-access.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
As of Dropwizard 4.12.0, the new logback-access 2.x is used, so we no longer have any need for the legacy 1.x version.

This removes the legacy 1.x logback-access dependencies. It also renames the property from logback-access-2_x.version to logback-access.version, since we no longer have multiple versions in the POM.

Closes #1270 