### PR TITLE
Remove logback from group exclusions in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,6 @@ updates:
         exclude-patterns:
           - "org.glassfish.jersey:*"
           - "jakarta.validation:jakarta.validation-api"
-          - "ch.qos.logback:*"
     assignees:
       - "sleberknight"
       - "chrisrohr"


### PR DESCRIPTION
Since Dropwizard 4.0.12 updated to the latest Logback dependencies, we don't need to exclude Logback from the dependency groups. So, remove ch.qos.logback
from the exclude-patterns.

Related to (but does not fix) #1245