### PR TITLE
Replace individual mongo deps with mongodb-driver-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,10 +90,8 @@
         <logback-classic.version>1.5.18</logback-classic.version>
         <logback-core.version>1.5.18</logback-core.version>
         <logstash.version>8.1</logstash.version>
-        <mongodb-driver-core.version>5.5.1</mongodb-driver-core.version>
-        <mongodb-driver-reactivestreams.version>5.5.1</mongodb-driver-reactivestreams.version>
-        <mongodb-driver-sync.version>5.5.1</mongodb-driver-sync.version>
-        <mongo-java-driver.version>3.12.14</mongo-java-driver.version>
+        <mongodb-driver-bom.version>5.5.1</mongodb-driver-bom.version>
+        <mongo-java-driver-deprecated.version>3.12.14</mongo-java-driver-deprecated.version>
         <mongo-java-server.version>1.47.0</mongo-java-server.version>
         <netty.version>4.2.2.Final</netty.version>
         <okhttp.version>4.12.0</okhttp.version>
@@ -587,20 +585,10 @@
 
             <dependency>
                 <groupId>org.mongodb</groupId>
-                <artifactId>mongodb-driver-core</artifactId>
-                <version>${mongodb-driver-core.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.mongodb</groupId>
-                <artifactId>mongodb-driver-reactivestreams</artifactId>
-                <version>${mongodb-driver-reactivestreams.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.mongodb</groupId>
-                <artifactId>mongodb-driver-sync</artifactId>
-                <version>${mongodb-driver-sync.version}</version>
+                <artifactId>mongodb-driver-bom</artifactId>
+                <version>${mongodb-driver-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <!-- DEPRECATED: This dependency will be removed in a future release. -->
@@ -611,7 +599,7 @@
             <dependency>
                 <groupId>org.mongodb</groupId>
                 <artifactId>mongo-java-driver</artifactId>
-                <version>${mongo-java-driver.version}</version>
+                <version>${mongo-java-driver-deprecated.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
* Replace mongodb-driver-core, mongodb-driver-reactivestreams, and mongodb-driver-sync with mongodb-driver-bom
* Rename the deprecated legacy MongoDB driver version from mongo-java-driver.version to mongo-java-driver-deprecated.version