### PR TITLE
Bump jersey-bom from 3.0.17 to 3.0.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <jaxws-rt.version>4.0.3</jaxws-rt.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
         <jdbi3.version>3.49.5</jdbi3.version>
-        <jersey.version>3.0.17</jersey.version>
+        <jersey.version>3.0.18</jersey.version>
         <jetbrains-annotations.version>26.0.2</jetbrains-annotations.version>
         <jetty.version>11.0.25</jetty.version>
         <joda-time.version>2.14.0</joda-time.version>


### PR DESCRIPTION
This is the latest 3.0.x (Jakarta EE 9) version, released 2025-06-17.