### PR TITLE
Bump hibernate version from 6.6.15 to 6.6.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <guava.version>33.4.8-jre</guava.version>
         <h2.version>2.3.232</h2.version>
         <hamcrest.version>3.0</hamcrest.version>
-        <hibernate.version>6.6.15.Final</hibernate.version>
+        <hibernate.version>6.6.20.Final</hibernate.version>
         <hibernate-validator.version>7.0.5.Final</hibernate-validator.version>
         <hk2.version>3.1.1</hk2.version>
         <httpclient.version>4.5.14</httpclient.version>


### PR DESCRIPTION
This is the latest 6.6.x version, released 2025-07-06.