### PR TITLE
Use spring-data-bom instead of individual dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,8 +101,7 @@
         <snakeyaml.version>2.4</snakeyaml.version>
         <slf4j.version>2.0.17</slf4j.version>
         <spring.version>6.2.8</spring.version>
-        <spring-data-commons.version>3.5.1</spring-data-commons.version>
-        <spring-data-mongodb.version>4.5.1</spring-data-mongodb.version>
+        <spring-data-bom.version>2025.0.1</spring-data-bom.version>
         <stax-ex.version>2.1.0</stax-ex.version>
         <stax2-api.version>4.2.2</stax2-api.version>
         <test-containers.version>1.21.3</test-containers.version>
@@ -668,14 +667,10 @@
 
             <dependency>
                 <groupId>org.springframework.data</groupId>
-                <artifactId>spring-data-commons</artifactId>
-                <version>${spring-data-commons.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.springframework.data</groupId>
-                <artifactId>spring-data-mongodb</artifactId>
-                <version>${spring-data-mongodb.version}</version>
+                <artifactId>spring-data-bom</artifactId>
+                <version>${spring-data-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
* Replace spring-data-commons and spring-data-mongodb with the Spring Data Release Train BOM, which maintains consistent versions across the Spring Data projects.

Closes #1332