### PR TITLE
Fix assertj.version property name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <angus-activation.version>2.0.2</angus-activation.version>
         <ant.version>1.10.15</ant.version>
         <archaius-core.version>0.7.12</archaius-core.version>
-        <assertj-guava.version>3.27.3</assertj-guava.version>
+        <assertj.version>3.27.3</assertj.version>
         <byte-buddy.version>1.17.6</byte-buddy.version>
         <caffeine.version>3.2.2</caffeine.version>
         <checker-qual.version>3.49.5</checker-qual.version>


### PR DESCRIPTION
* Rename assertj-guava to assertj.version

Note that while this is technically a bug, the BOM still worked as expected since kiwi-parent defines am assertj.version property, which is inherited.

Fixes #1336