### PR TITLE
Security: Use Use full commit SHA hash for flagged GitHub actions

### DIFF
--- a/.github/workflows/update-license-copyright-years.yml
+++ b/.github/workflows/update-license-copyright-years.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: FantasticFiasco/action-update-license-year@v3
+      - uses: FantasticFiasco/action-update-license-year@d837fc83ecb71196807bdf3854208f556e66f6ed
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: LICENSE.txt


### PR DESCRIPTION
* Change FantasticFiasco/action-update-license-year to use full commit hash