### PR TITLE
Bump byte-buddy and error_prone_annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <apiguardian-api.version>1.1.2</apiguardian-api.version>
         <archaius-core.version>0.7.12</archaius-core.version>
         <assertj.version>3.27.6</assertj.version>
-        <byte-buddy.version>1.18.1</byte-buddy.version>
+        <byte-buddy.version>1.18.2</byte-buddy.version>
         <caffeine.version>3.2.3</caffeine.version>
         <checker-qual.version>3.52.0</checker-qual.version>
         <classmate.version>1.7.1</classmate.version>
@@ -49,7 +49,7 @@
         <dropwizard.version>4.0.16</dropwizard.version>
         <dropwizard.metrics.version>4.2.37</dropwizard.metrics.version>
         <embedded-postgres.version>2.2.0</embedded-postgres.version>
-        <error-prone-annotations.version>2.44.0</error-prone-annotations.version>
+        <error-prone-annotations.version>2.45.0</error-prone-annotations.version>
         <eureka.version>1.10.18</eureka.version>
         <fastinfoset.version>2.1.1</fastinfoset.version>
         <guava.version>33.5.0-jre</guava.version>


### PR DESCRIPTION
* Updates net.bytebuddy:byte-buddy-parent from 1.18.1 to 1.18.2
* Updates com.google.errorprone:error_prone_annotations from 2.44.0 to 2.45.0