### PR TITLE
Update dependencies and bump version to 3.0.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>kiwi-bom</artifactId>
-    <version>2.3.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -46,7 +46,7 @@
         <commons-net.version>3.12.0</commons-net.version>
         <commons-text.version>1.14.0</commons-text.version>
         <curator.version>5.9.0</curator.version>
-        <dropwizard.version>4.0.16</dropwizard.version>
+        <dropwizard.version>5.0.0</dropwizard.version>
         <dropwizard.metrics.version>4.2.37</dropwizard.metrics.version>
         <embedded-postgres.version>2.2.0</embedded-postgres.version>
         <error-prone-annotations.version>2.45.0</error-prone-annotations.version>
@@ -55,8 +55,8 @@
         <guava.version>33.5.0-jre</guava.version>
         <h2.version>2.4.240</h2.version>
         <hamcrest.version>3.0</hamcrest.version>
-        <hibernate.version>6.6.20.Final</hibernate.version>
-        <hibernate-validator.version>7.0.5.Final</hibernate-validator.version>
+        <hibernate.version>6.6.38.Final</hibernate.version>
+        <hibernate-validator.version>8.0.3.Final</hibernate-validator.version>
         <hk2.version>3.1.1</hk2.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpclient5.version>5.5.1</httpclient5.version>
@@ -67,21 +67,22 @@
         <jakarta.activation-api.version>2.1.4</jakarta.activation-api.version>
         <jakarta.activation-api.sun.version>2.0.1</jakarta.activation-api.sun.version>
         <jakarta.el.version>4.0.2</jakarta.el.version>
-        <jakarta.inject-api.version>2.0.1.MR</jakarta.inject-api.version>
+        <jakarta.el-api.version>5.0.1</jakarta.el-api.version>
+        <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
         <jakarta.mail-api.version>2.1.5</jakarta.mail-api.version>
-        <jakarta.ws.rs-api.version>3.0.0</jakarta.ws.rs-api.version>
-        <jakarta.servlet-api.version>5.0.0</jakarta.servlet-api.version>
+        <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
+        <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
         <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
-        <jakarta.xml.bind-api.version>3.0.1</jakarta.xml.bind-api.version>
+        <jakarta.xml.bind-api.version>4.0.4</jakarta.xml.bind-api.version>
         <javassist.version>3.30.2-GA</javassist.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <jaxb.glassfish.version>4.0.6</jaxb.glassfish.version>
         <jaxws-rt.version>4.0.3</jaxws-rt.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
         <jdbi3.version>3.50.0</jdbi3.version>
-        <jersey.version>3.0.18</jersey.version>
+        <jersey.version>3.1.11</jersey.version>
         <jetbrains-annotations.version>26.0.2-1</jetbrains-annotations.version>
-        <jetty.version>11.0.26</jetty.version>
+        <jetty.version>12.1.4</jetty.version>
         <joda-time.version>2.14.0</joda-time.version>
         <jsonassert.version>1.5.3</jsonassert.version>
         <jsch.version>0.1.55</jsch.version>
@@ -103,8 +104,8 @@
         <servo-core.version>0.13.2</servo-core.version>
         <snakeyaml.version>2.5</snakeyaml.version>
         <slf4j.version>2.0.17</slf4j.version>
-        <spring.version>6.2.12</spring.version>
-        <spring-data-bom.version>2025.0.5</spring-data-bom.version>
+        <spring.version>7.0.1</spring.version>
+        <spring-data-bom.version>2025.1.0</spring-data-bom.version>
         <stax-ex.version>2.1.0</stax-ex.version>
         <stax2-api.version>4.2.2</stax2-api.version>
         <test-containers.version>2.0.2</test-containers.version>
@@ -398,10 +399,17 @@
                 <version>${jakarta.annotation-api.version}</version>
             </dependency>
 
+            <!-- TODO: Can we remove this? -->
             <dependency>
                 <groupId>org.glassfish</groupId>
                 <artifactId>jakarta.el</artifactId>
                 <version>${jakarta.el.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.el</groupId>
+                <artifactId>jakarta.el-api</artifactId>
+                <version>${jakarta.el-api.version}</version>
             </dependency>
 
             <dependency>
@@ -553,12 +561,6 @@
             <dependency>
                 <groupId>ch.qos.logback.access</groupId>
                 <artifactId>logback-access-common</artifactId>
-                <version>${logback-access.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>ch.qos.logback.access</groupId>
-                <artifactId>logback-access-jetty11</artifactId>
                 <version>${logback-access.version}</version>
             </dependency>
 


### PR DESCRIPTION
Version updates:

- Bump dropwizard from 4.0.16 to 5.0.0
- Bump hibernate-core from 6.6.20.Final to 6.6.38.Final
- Bump hibernate-validator from 7.0.5.Final to 8.0.3.Final
- Bump jakarta.inject-api from 2.0.1.MR to 2.0.1
- Bump jakarta.ws.rs-api from 3.0.0 to 3.1.0
- Bump jakarta.servlet-api from 5.0.0 to 6.0.0
- Bump jakarta.xml.bind-api from 3.0.1 to 4.0.4
- Bump jersey from 3.0.18 to 3.1.11
- Bump jetty from 11.0.26 to 12.1.4
- Bump spring from 6.2.12 to 7.0.1
- Bump spring-data-bom from 2025.0.5 to 2025.1.0

Additions:

- Add jakarta.el-api 5.0.1

Removals:

- Remove logback-access-jetty11