### PR TITLE
Exclude jakarta.servlet-api from Dependabot grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,7 @@ updates:
           - "patch"
         exclude-patterns:
           - "org.glassfish.jersey:*"
+          - "jakarta.servlet:jakarta.servlet-api:*"
           - "jakarta.validation:jakarta.validation-api"
     assignees:
       - "sleberknight"


### PR DESCRIPTION
We unfortunately need to do this because Servlet API 6.0.x is Jakarta EE 10 while 6.1.x is EE 11.