### PR TITLE
Add dependency for jsch fork: com.github.mwiede:jsch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
         <joda-time.version>2.14.2</joda-time.version>
         <jsonassert.version>1.5.3</jsonassert.version>
         <jsch.version>0.1.55</jsch.version>
+        <jsch-mwiede-fork.version>2.28.2</jsch-mwiede-fork.version>
         <jspecify.version>1.0.0</jspecify.version>
         <jsr305.version>3.0.2</jsr305.version>
         <junixsocket.version>2.10.1</junixsocket.version>
@@ -561,10 +562,18 @@
                 <version>${jsonassert.version}</version>
             </dependency>
 
+            <!-- Original jsch library; is unmaintained and replaced by the mwiede fork -->
             <dependency>
                 <groupId>com.jcraft</groupId>
                 <artifactId>jsch</artifactId>
                 <version>${jsch.version}</version>
+            </dependency>
+
+            <!-- Fork of the jsck library: see https://github.com/mwiede/jsch -->
+            <dependency>
+                <groupId>com.github.mwiede</groupId>
+                <artifactId>jsch</artifactId>
+                <version>${jsch-mwiede-fork.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
com.github.mwiede:jsch replaces the original com.jcraft library. We will eventually remove the original com.jcraft one from this BOM.