### PR TITLE
Add Jackson 3 BOM dependency management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,0 @@
-# Claude Guidelines for kiwi-bom
-
-## Commits and Pull Requests
-- Do not include Claude session URLs in commit messages or PR descriptions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+# Claude Guidelines for kiwi-bom
+
+## Commits and Pull Requests
+- Do not include Claude session URLs in commit messages or PR descriptions.

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>kiwi-bom</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -77,6 +77,7 @@
         <httpcore5.version>5.4.2</httpcore5.version>
         <httpcore5-h2.version>5.4.2</httpcore5-h2.version>
         <jackson.version>2.22.0</jackson.version>
+        <jackson3.version>3.2.0</jackson3.version>
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
         <jakarta.activation-api.version>2.1.4</jakarta.activation-api.version>
         <jakarta.activation-api.sun.version>2.0.1</jakarta.activation-api.sun.version>
@@ -400,6 +401,14 @@
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>tools.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson3.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <httpcore5.version>5.4.2</httpcore5.version>
         <httpcore5-h2.version>5.4.2</httpcore5-h2.version>
         <jackson.version>2.22.0</jackson.version>
-        <jackson3.version>3.2.0</jackson3.version>
+        <jackson3.version>3.1.4</jackson3.version>
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
         <jakarta.activation-api.version>2.1.4</jakarta.activation-api.version>
         <jakarta.activation-api.sun.version>2.0.1</jakarta.activation-api.sun.version>


### PR DESCRIPTION
This change adds support for Jackson 3 in the kiwi-bom bill of materials by introducing a new Jackson 3 BOM import and updating the project version to reflect the minor version bump.

- Bumped project version from 3.2.1-SNAPSHOT to 3.3.0-SNAPSHOT
- Added jackson3.version property set to 3.1.4
- Added Jackson 3 BOM (tools.jackson:jackson-bom) as an imported dependency with scope import for centralized dependency management

The Jackson 3 BOM is added alongside the existing Jackson 2 BOM, allowing projects using this bill of materials to manage Jackson 3 dependencies consistently. The BOM import approach ensures that all Jackson 3 transitive dependencies are properly versioned and conflict-free.