### PR TITLE
chore: add Dependabot cooldown for maven updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,10 @@ updates:
       - "sleberknight"
       - "chrisrohr"
     open-pull-requests-limit: 10
+    cooldown:
+      semver-patch-days: 5
+      semver-minor-days: 14
+      semver-major-days: 30
     commit-message:
       prefix: "chore(deps)"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Add cooldown periods to the maven package ecosystem to reduce noise from immediate minor/patch dependency updates.