### PR TITLE
deps: restrict hibernate-core and hibernate-validator versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "org.hibernate.orm:hibernate-core"
+        versions: [ ">=7" ]
+      - dependency-name: "org.hibernate.validator:hibernate-validator"
+        versions: [ ">=9" ]
     groups:
       dev-deps:
         dependency-type: "development"


### PR DESCRIPTION
Restrict hibernate-core and hibernate-validator versions to those supported by Dropwizard 5.x, currently 6.x and 8.x, respectively.