### PR TITLE
deps: remove httpclient5 from dependabot exclusions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,6 @@ updates:
           - "org.glassfish.jersey:*"
           - "jakarta.servlet:jakarta.servlet-api"
           - "jakarta.validation:jakarta.validation-api"
-          - "org.apache.httpcomponents.client5:httpclient5"
     assignees:
       - "sleberknight"
       - "chrisrohr"


### PR DESCRIPTION
Dropwizard resolved the issue at httpclient5 version 5.6.x so we can now let it update.