### PR TITLE
deps: restrict org.glassfish.jersey versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
         versions: [ ">=7" ]
       - dependency-name: "org.hibernate.validator:hibernate-validator"
         versions: [ ">=9" ]
+      - dependency-name: "org.glassfish.jersey:*"
+        versions: [ ">= 4" ]
     groups:
       dev-deps:
         dependency-type: "development"
@@ -21,7 +23,6 @@ updates:
           - "minor"
           - "patch"
         exclude-patterns:
-          - "org.glassfish.jersey:*"
           - "jakarta.servlet:jakarta.servlet-api"
           - "jakarta.validation:jakarta.validation-api"
     assignees:


### PR DESCRIPTION
Restrict jersey versions to those supported by Dropwizard 5.x, currently 3.1.x