### PR TITLE
deps: restrict servlet-api and validation-api versions to Jakarta EE 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
         versions: [ ">=9" ]
       - dependency-name: "org.glassfish.jersey:*"
         versions: [ ">= 4" ]
+      - dependency-name: "jakarta.servlet:jakarta.servlet-api"
+        versions: [ ">=6.1" ]
+      - dependency-name: "jakarta.validation:jakarta.validation-api"
+        versions: [ ">=3.1" ]
     groups:
       dev-deps:
         dependency-type: "development"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,9 +26,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-        exclude-patterns:
-          - "jakarta.servlet:jakarta.servlet-api"
-          - "jakarta.validation:jakarta.validation-api"
     assignees:
       - "sleberknight"
       - "chrisrohr"


### PR DESCRIPTION
Restrict servlet-api and validation-api versions to those supported by Dropwizard 5.x, which are the versions for Jakarta EE 10.