### PR TITLE
chore(deps): block dependabot from bumping logback past 1.5.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,13 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
+      # logback-classic 1.6.x removed PatternLayout.DEFAULT_CONVERTER_MAP, which breaks
+      # dropwizard's LogbackAccessRequestLayout (NoSuchFieldError). Unblock once dropwizard
+      # supports logback 1.6.x (see dropwizard/dropwizard#11262, #11265).
+      - dependency-name: "ch.qos.logback:logback-classic"
+        versions: [ ">=1.6" ]
+      - dependency-name: "ch.qos.logback:logback-core"
+        versions: [ ">=1.6" ]
       - dependency-name: "org.hibernate.orm:hibernate-core"
         versions: [ ">=7" ]
       - dependency-name: "org.hibernate.validator:hibernate-validator"


### PR DESCRIPTION
## Summary
- `logback-classic`/`logback-core` 1.6.x remove `PatternLayout.DEFAULT_CONVERTER_MAP`, which breaks dropwizard's `LogbackAccessRequestLayout` with a `NoSuchFieldError` at runtime (see [dropwizard/dropwizard#11262](https://github.com/dropwizard/dropwizard/pull/11262) and the fix attempt in [#11265](https://github.com/dropwizard/dropwizard/pull/11265), which is still open/unmerged).
- Dropwizard's own logback 1.6.1 update PR ([#11273](https://github.com/dropwizard/dropwizard/pull/11273)) is currently still failing CI with a compile error, so 1.6.x isn't safe to consume yet even with the pending fix.
- Adds a dependabot `ignore` rule for `ch.qos.logback:logback-classic` and `ch.qos.logback:logback-core` at `>=1.6`, so dependabot can't open a PR bumping past 1.5.x until dropwizard supports the 1.6.x series. 1.5.x patch/minor updates are unaffected.

## Test plan
- [x] Confirm dependabot config is valid YAML (CI should pass)
- [ ] Re-enable/remove this ignore rule once dropwizard officially supports logback 1.6.x

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pnm98svfwo2hbKSyGE8ENq)_